### PR TITLE
feat: Sidebar

### DIFF
--- a/components/Sidebar/Sidebar.tsx
+++ b/components/Sidebar/Sidebar.tsx
@@ -1,0 +1,27 @@
+import SidebarRow from './SidebarRow';
+import {
+  BellIcon,
+  HashtagIcon,
+  HomeIcon,
+  MailIcon,
+  CollectionIcon,
+  BookmarkIcon,
+  UserIcon,
+  DotsCircleHorizontalIcon,
+} from '@heroicons/react/outline';
+
+export const Sidebar = () => {
+  return (
+    <div>
+      <img className="h-10 w-10" src="https://links.papareact.com/drq" alt="twitter home" />
+      <SidebarRow Icon={HomeIcon} title="Home" />
+      <SidebarRow Icon={HashtagIcon} title="Explore" />
+      <SidebarRow Icon={BellIcon} title="Notifications" />
+      <SidebarRow Icon={MailIcon} title="Messages" />
+      <SidebarRow Icon={BookmarkIcon} title="Bookmarks" />
+      <SidebarRow Icon={CollectionIcon} title="Lists" />
+      <SidebarRow Icon={UserIcon} title="Sign in" />
+      <SidebarRow Icon={DotsCircleHorizontalIcon} title="More" />
+    </div>
+  );
+};

--- a/components/Sidebar/SidebarRow.tsx
+++ b/components/Sidebar/SidebarRow.tsx
@@ -1,0 +1,17 @@
+import React, { SVGProps } from 'react';
+
+interface Props {
+  Icon: (props: SVGProps<SVGSVGElement>) => JSX.Element;
+  title: string;
+}
+
+const SidebarRow = ({ Icon, title }: Props) => {
+  return (
+    <a className="group flex items-center max-w-fit space-x-2 rounded-full px-4 py-3 cursor-pointer transition-all duration-200 hover:bg-gray-100">
+      <Icon className="h-6 w-6" />
+      <span className="group-hover:text-twitter">{title}</span>
+    </a>
+  );
+};
+
+export default SidebarRow;

--- a/components/Sidebar/index.tsx
+++ b/components/Sidebar/index.tsx
@@ -1,0 +1,1 @@
+export * from './Sidebar';

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -1,0 +1,1 @@
+export * from './Sidebar';

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,7 +4,7 @@ import Head from 'next/head';
 
 const Home: NextPage = () => {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center py-2">
+    <div className="">
       <Head>
         <title>Twitter Clone</title>
         <link rel="icon" href="/favicon.ico" />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,3 +1,4 @@
+import { Sidebar } from 'components';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 
@@ -9,7 +10,7 @@ const Home: NextPage = () => {
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <main>
-        {/* Sidebar */}
+        <Sidebar />
         {/* Feed */}
         {/* Widgets */}
       </main>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,12 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [
-    './pages/**/*.{js,ts,jsx,tsx}',
-    './components/**/*.{js,ts,jsx,tsx}',
-  ],
+  content: ['./pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        twitter: 'hsl(196, 100%, 46%)',
+      },
+    },
+    plugins: [],
   },
-  plugins: [],
-}
+};


### PR DESCRIPTION
## What I did 
![image](https://user-images.githubusercontent.com/35516239/177663172-bcf6c947-2ef4-4eed-b7b2-0dc8b6852238.png)

## What I learn 
- [JSX.Element not defined](https://www.notion.so/piknow/JSX-Element-not-defined-db8e7cf64e8f460992be8b94944d7f63) 이슈  
### react component 함수를 prop으로 넘겨서 subComponent에서 prop으로 전달받은 component를 jsx로 표기해서 실행 
![image](https://user-images.githubusercontent.com/35516239/177663495-d06060bb-079b-42f7-9dbe-967577bb5d3d.png)
- 단 이 때 react Component 임을 알 수 있도록, prop의 key를  Pascal Case 표기 
- 왜 이렇게 구현 했냐 하면, Icon에 공통 className을 주입시키고 싶은데, `<Icon className="h-6 w-6" />` 처럼 jsx.element 자체를 넘기게 되면 prop 으로 전달할 때 마다 h-6, w-6을 써줘야 했기 때문
- className을 공통으로 쓰기 위한 전략임

close #3 