### PR TITLE
feat: Widgets

### DIFF
--- a/components/Widgets/Widgets.tsx
+++ b/components/Widgets/Widgets.tsx
@@ -1,0 +1,19 @@
+import { SearchIcon } from '@heroicons/react/outline';
+import { TwitterTimelineEmbed } from 'react-twitter-embed';
+
+export const Widgets = () => {
+  return (
+    <div className="mt-2 px-2">
+      {/* Search Box  */}
+      <div className="mt-2 flex items-center space-x-2 rounded-full bg-gray-100 p-3">
+        <SearchIcon className="h-5 w-5 text-gray-400" />
+        <input
+          type="text"
+          placeholder="Search Twitter"
+          className=" flex-1 outline-none bg-transparent"
+        />
+      </div>
+      <TwitterTimelineEmbed sourceType="profile" screenName="iknow_p" options={{ height: 1000 }} />
+    </div>
+  );
+};

--- a/components/Widgets/Widgets.tsx
+++ b/components/Widgets/Widgets.tsx
@@ -4,13 +4,12 @@ import { TwitterTimelineEmbed } from 'react-twitter-embed';
 export const Widgets = () => {
   return (
     <div className="mt-2 px-2">
-      {/* Search Box  */}
       <div className="mt-2 flex items-center space-x-2 rounded-full bg-gray-100 p-3">
         <SearchIcon className="h-5 w-5 text-gray-400" />
         <input
           type="text"
           placeholder="Search Twitter"
-          className=" flex-1 outline-none bg-transparent"
+          className="flex-1 outline-none bg-transparent"
         />
       </div>
       <TwitterTimelineEmbed sourceType="profile" screenName="iknow_p" options={{ height: 1000 }} />

--- a/components/Widgets/index.tsx
+++ b/components/Widgets/index.tsx
@@ -1,0 +1,1 @@
+export * from './Widgets';

--- a/components/index.tsx
+++ b/components/index.tsx
@@ -1,2 +1,3 @@
 export * from './Sidebar';
 export * from './Feed';
+export * from './Widgets';

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "@heroicons/react": "^1.0.6",
     "next": "latest",
     "react": "18.1.0",
-    "react-dom": "18.1.0"
+    "react-dom": "18.1.0",
+    "react-twitter-embed": "^4.0.4"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^12.1.6",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,4 @@
-import { Feed, Sidebar } from 'components';
+import { Feed, Sidebar, Widgets } from 'components';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 
@@ -12,7 +12,7 @@ const Home: NextPage = () => {
       <main>
         <Sidebar />
         <Feed />
-        {/* Widgets */}
+        <Widgets />
       </main>
     </div>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2773,6 +2773,13 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-twitter-embed@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/react-twitter-embed/-/react-twitter-embed-4.0.4.tgz#4a6b8354acc266876ff1110b9f648518ea20db6d"
+  integrity sha512-2JIL7qF+U62zRzpsh6SZDXNI3hRNVYf5vOZ1WRcMvwKouw+xC00PuFaD0aEp2wlyGaZ+f4x2VvX+uDadFQ3HVA==
+  dependencies:
+    scriptjs "^2.5.9"
+
 react@18.1.0:
   version "18.1.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.1.0.tgz#6f8620382decb17fdc5cc223a115e2adbf104890"
@@ -2920,6 +2927,11 @@ scheduler@^0.22.0:
   integrity sha512-6QAm1BgQI88NPYymgGQLCZgvep4FyePDWFpXVK+zNSUgHwlqpJy8VEh8Et0KxTACS4VWwMousBElAZOH9nkkoQ==
   dependencies:
     loose-envify "^1.1.0"
+
+scriptjs@^2.5.9:
+  version "2.5.9"
+  resolved "https://registry.yarnpkg.com/scriptjs/-/scriptjs-2.5.9.tgz#343915cd2ec2ed9bfdde2b9875cd28f59394b35f"
+  integrity sha512-qGVDoreyYiP1pkQnbnFAUIS5AjenNwwQBdl7zeos9etl+hYKWahjRTfzAZZYBv5xNHx7vNKCmaLDQZ6Fr2AEXg==
 
 semver@^6.3.0:
   version "6.3.0"


### PR DESCRIPTION
## What I did 

<img width="920" alt="image" src="https://user-images.githubusercontent.com/35516239/179351187-5c91d59e-068d-4887-a673-6b4d993c55f8.png">

## What I learn 

### input text의 bg-transfer 가 필요한 이유 

<img width="1083" alt="image" src="https://user-images.githubusercontent.com/35516239/179351258-03e78874-1b75-42cb-83eb-340e1bc564c4.png">
<img width="939" alt="image" src="https://user-images.githubusercontent.com/35516239/179351265-ccb13d42-af32-47cb-9c3d-7d10b12be7bb.png">

### input text에 flex-1 적용 해야 하는 이유 
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/35516239/179351575-ba7d9671-29e5-4039-b3db-b50ddd6b72e4.png">
- input tag 는 최소한의 width만을 기본으로 가지려 하므로 flex1을 통해 가질 수 있는 너비를 모두 가지게 만든다. 

<img width="552" alt="image" src="https://user-images.githubusercontent.com/35516239/179351649-49a5a861-f3d8-46be-9583-1b61dd10e25d.png">


<img width="1093" alt="image" src="https://user-images.githubusercontent.com/35516239/179351637-31f0b8bc-b219-4848-9fea-1ff95cda1268.png">


### twitter widget 내용을 채우기 위한 패키지 [react-twitter-embed](https://github.com/saurabhnemade/react-twitter-embed)
- 이 패키지를 사용하면 screenName property에 기입한 아이디에 기반한 twit 내용을 가져와서 보여준다. 
<img width="993" alt="image" src="https://user-images.githubusercontent.com/35516239/179351332-916e4ced-6ac0-4a02-b1a7-87f549424b0b.png">


